### PR TITLE
Fix Gemini 400 bad request by providing fallback thoughtSignature

### DIFF
--- a/app/translator.py
+++ b/app/translator.py
@@ -114,6 +114,8 @@ def _msg_to_gemini_parts(msg: dict, id_to_name: dict[str, str], id_to_sig: dict[
             part = {"functionCall": fc}
             if tid and tid in id_to_sig:
                 part["thoughtSignature"] = id_to_sig[tid]
+            else:
+                part["thoughtSignature"] = "skip_thought_signature_validator"
             parts.append(part)
 
         elif btype == "tool_result":


### PR DESCRIPTION
When using Gemini tools or injected function calls missing an explicit thoughtSignature from a previous assistant message, the Gemini API errors with a 400 Bad Request. According to the Gemini documentation, passing the magic string `skip_thought_signature_validator` bypasses this strict validation. This PR adds a default fallback in `_msg_to_gemini_parts` to avoid the error.

---
*PR created automatically by Jules for task [11625072607064101598](https://jules.google.com/task/11625072607064101598) started by @Baba01hacker666*