### PR TITLE
Add Ollama upstream proxy support and fix streaming robustness bugs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,8 @@ _load_dotenv()
 GEMINI_API_KEY  = os.getenv("GEMINI_API_KEY", "")
 PROXY_API_KEY   = os.getenv("PROXY_API_KEY")
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+UPSTREAM_PROVIDER = os.getenv("UPSTREAM_PROVIDER", "gemini").strip().lower()
 PROXY_PORT      = int(os.getenv("PROXY_PORT", 8083))
 LOG_LEVEL       = os.getenv("LOG_LEVEL", "INFO")
 

--- a/app/proxy.py
+++ b/app/proxy.py
@@ -3,12 +3,14 @@ import time
 import uuid
 import httpx
 from http.server import BaseHTTPRequestHandler
-from app.config import GEMINI_API_KEY, PROXY_API_KEY, GEMINI_BASE_URL
+from app.config import GEMINI_API_KEY, PROXY_API_KEY, GEMINI_BASE_URL, OLLAMA_BASE_URL, UPSTREAM_PROVIDER
 from app.logger import log_req
 from app.schema import validate_anthropic_request
 from app.translator import (
     build_gemini_payload,
+    build_ollama_payload,
     gemini_response_to_anthropic,
+    ollama_response_to_anthropic,
     gemini_finish_to_anthropic,
     extract_usage
 )
@@ -37,9 +39,13 @@ class ProxyHandler(BaseHTTPRequestHandler):
         self._send_json(status, error_payload)
 
     def _gemini_headers(self) -> dict:
+        if UPSTREAM_PROVIDER == "ollama":
+            return {"Content-Type": "application/json"}
         return {"Content-Type": "application/json", "x-goog-api-key": GEMINI_API_KEY}
 
     def _gemini_url(self, model: str, stream: bool) -> str:
+        if UPSTREAM_PROVIDER == "ollama":
+            return f"{OLLAMA_BASE_URL}/api/chat"
         method = "streamGenerateContent" if stream else "generateContent"
         url = f"{GEMINI_BASE_URL}/models/{model}:{method}"
         return url + "?alt=sse" if stream else url
@@ -49,10 +55,10 @@ class ProxyHandler(BaseHTTPRequestHandler):
         if self.path.split("?")[0] in ("/", "/health"):
             self._send_json(200, {
                 "status":        "ok",
-                "service":       "DCT Claude→Gemini Proxy v2.5",
+                "service":       f"DCT Claude→{UPSTREAM_PROVIDER.capitalize()} Proxy v2.5",
                 "default_model": DEFAULT_MODEL,
                 "small_model":   SMALL_MODEL,
-                "upstream":      GEMINI_BASE_URL,
+                "upstream":      OLLAMA_BASE_URL if UPSTREAM_PROVIDER == "ollama" else GEMINI_BASE_URL,
             })
         else:
             self._send_error(404, "not found")
@@ -90,7 +96,10 @@ class ProxyHandler(BaseHTTPRequestHandler):
                      original_model, is_streaming, len(body.get("messages", [])))
 
         try:
-            gem_payload, original_model, gemini_model = build_gemini_payload(body)
+            if UPSTREAM_PROVIDER == "ollama":
+                gem_payload, original_model, gemini_model = build_ollama_payload(body)
+            else:
+                gem_payload, original_model, gemini_model = build_gemini_payload(body)
         except Exception as e:
             log_req.error("Payload build failed: %s", e, exc_info=True)
             self._send_error(400, f"payload build error: {e}")
@@ -117,7 +126,11 @@ class ProxyHandler(BaseHTTPRequestHandler):
 
         try:
             gem_json = resp.json()
-            anthropic_resp = gemini_response_to_anthropic(gem_json, original_model)
+            anthropic_resp = (
+                ollama_response_to_anthropic(gem_json, original_model)
+                if UPSTREAM_PROVIDER == "ollama"
+                else gemini_response_to_anthropic(gem_json, original_model)
+            )
         except Exception as e:
             self._send_error(500, f"Translation Error: {e}")
             return
@@ -166,6 +179,36 @@ class ProxyHandler(BaseHTTPRequestHandler):
         final_usage = {"input_tokens": 0, "output_tokens": 0}
 
         try:
+            if UPSTREAM_PROVIDER == "ollama":
+                with httpx.Client(timeout=180.0) as client:
+                    with client.stream("POST", url, headers=self._gemini_headers(), json=gem_payload) as resp:
+                        if resp.status_code != 200:
+                            send_error_event(f"Ollama API Error {resp.status_code}: {resp.read().decode(errors='replace')[:200]}")
+                            return
+                        for line in resp.iter_lines():
+                            if not line:
+                                continue
+                            if isinstance(line, bytes):
+                                line = line.decode(errors="replace")
+                            try:
+                                chunk = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
+                            text_chunk = ((chunk.get("message") or {}).get("content")) or ""
+                            if text_chunk:
+                                if not text_block_open:
+                                    text_block_idx, next_block_idx = next_block_idx, next_block_idx + 1
+                                    text_block_open = True
+                                    write_sse("content_block_start", {"type": "content_block_start", "index": text_block_idx, "content_block": {"type": "text", "text": ""}})
+                                write_sse("content_block_delta", {"type": "content_block_delta", "index": text_block_idx, "delta": {"type": "text_delta", "text": text_chunk}})
+                            if chunk.get("done") is True:
+                                break
+                if text_block_open:
+                    write_sse("content_block_stop", {"type": "content_block_stop", "index": text_block_idx})
+                write_sse("message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": None}, "usage": final_usage})
+                write_sse("message_stop", {"type": "message_stop"})
+                return
+
             with httpx.Client(timeout=180.0) as client:
                 with client.stream("POST", url, headers=self._gemini_headers(), json=gem_payload) as resp:
                     if resp.status_code != 200:
@@ -173,6 +216,8 @@ class ProxyHandler(BaseHTTPRequestHandler):
                         return
 
                     for line in resp.iter_lines():
+                        if isinstance(line, bytes):
+                            line = line.decode(errors="replace")
                         if not line.startswith("data: "): continue
                         raw = line[6:].strip()
                         if not raw: continue

--- a/app/server.py
+++ b/app/server.py
@@ -1,6 +1,6 @@
 import threading
 from http.server import HTTPServer
-from app.config import PROXY_PORT, GEMINI_API_KEY, DEFAULT_MODEL, PROXY_API_KEY
+from app.config import PROXY_PORT, GEMINI_API_KEY, DEFAULT_MODEL, PROXY_API_KEY, UPSTREAM_PROVIDER
 from app.proxy import ProxyHandler
 
 class ThreadedHTTPServer(HTTPServer):
@@ -13,7 +13,7 @@ class ThreadedHTTPServer(HTTPServer):
         finally: self.shutdown_request(request)
 
 def run_server():
-    if not GEMINI_API_KEY:
+    if UPSTREAM_PROVIDER == "gemini" and not GEMINI_API_KEY:
         raise RuntimeError("GEMINI_API_KEY is not set — add it to .env or export it")
 
     server = ThreadedHTTPServer(("0.0.0.0", PROXY_PORT), ProxyHandler)

--- a/app/translator.py
+++ b/app/translator.py
@@ -221,6 +221,54 @@ def build_gemini_payload(body: dict) -> tuple[dict, str, str]:
 
     return payload, original_model, gemini_model
 
+def build_ollama_payload(body: dict) -> tuple[dict, str, str]:
+    original_model = body.get("model", "claude-sonnet-4-6")
+    ollama_model   = resolve_model(original_model)
+    messages = body.get("messages", [])
+    id_to_name, id_to_sig = build_tool_metadata(messages)
+    contents = anthropic_messages_to_gemini(messages, id_to_name, id_to_sig)
+    system_text = normalise_system(body.get("system"))
+
+    ollama_messages: list[dict] = []
+    if system_text:
+        ollama_messages.append({"role": "system", "content": system_text})
+    for msg in contents:
+        parts = msg.get("parts", [])
+        text = "\n".join(p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text"))
+        if text:
+            ollama_messages.append({"role": "assistant" if msg.get("role") == "model" else "user", "content": text})
+
+    payload: dict[str, Any] = {
+        "model": ollama_model,
+        "messages": ollama_messages,
+        "stream": bool(body.get("stream", False)),
+    }
+    options: dict[str, Any] = {}
+    if body.get("max_tokens"):
+        options["num_predict"] = body["max_tokens"]
+    if body.get("temperature") is not None:
+        options["temperature"] = body["temperature"]
+    if body.get("top_p") is not None:
+        options["top_p"] = body["top_p"]
+    if body.get("stop_sequences"):
+        options["stop"] = body["stop_sequences"]
+    if options:
+        payload["options"] = options
+    return payload, original_model, ollama_model
+
+def ollama_response_to_anthropic(resp: dict, original_model: str) -> dict:
+    text = ((resp.get("message") or {}).get("content")) or resp.get("response") or ""
+    return {
+        "id": f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "role": "assistant",
+        "model": original_model,
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+
 # ─── Gemini → Anthropic Conversion ───────────────────────────────────────────
 _FINISH_MAP: dict[str | None, str] = {
     "STOP":                       "end_turn",

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,5 +1,5 @@
 import unittest
-from app.translator import anthropic_messages_to_gemini, gemini_response_to_anthropic
+from app.translator import anthropic_messages_to_gemini, gemini_response_to_anthropic, build_ollama_payload, ollama_response_to_anthropic
 
 class TestTranslator(unittest.TestCase):
     def test_anthropic_messages_to_gemini_text(self):
@@ -39,6 +39,26 @@ class TestTranslator(unittest.TestCase):
         self.assertEqual(anthropic_response["stop_reason"], "end_turn")
         self.assertEqual(anthropic_response["usage"]["input_tokens"], 10)
         self.assertEqual(anthropic_response["usage"]["output_tokens"], 5)
+
+    def test_build_ollama_payload_text(self):
+        body = {
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "Hello Ollama"}],
+            "stream": True,
+            "temperature": 0.2,
+        }
+        payload, original_model, _ = build_ollama_payload(body)
+        self.assertEqual(original_model, "claude-3-5-sonnet-20241022")
+        self.assertTrue(payload["stream"])
+        self.assertEqual(payload["messages"][0]["role"], "user")
+        self.assertEqual(payload["messages"][0]["content"], "Hello Ollama")
+        self.assertEqual(payload["options"]["temperature"], 0.2)
+
+    def test_ollama_response_to_anthropic_text(self):
+        resp = {"message": {"content": "Hi from Ollama"}}
+        anthropic_response = ollama_response_to_anthropic(resp, "claude-sonnet-4-6")
+        self.assertEqual(anthropic_response["role"], "assistant")
+        self.assertEqual(anthropic_response["content"][0]["text"], "Hi from Ollama")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Support routing the proxy to Ollama in addition to Gemini so users can run against a local Ollama instance.
- Fix robustness issues in streaming handling where byte lines were not decoded before string operations, causing parsing failures.
- Preserve the existing Gemini behavior while enabling a compatible text-path for Ollama streaming and sync responses.

### Description
- Add `OLLAMA_BASE_URL` and `UPSTREAM_PROVIDER` to `app/config.py` and wire provider selection throughout the codebase so the proxy can target either `gemini` or `ollama` at runtime.
- Implement `build_ollama_payload` and `ollama_response_to_anthropic` in `app/translator.py`, and update `app/proxy.py` to use those helpers for sync requests and to handle Ollama streaming (`/api/chat`) while keeping Gemini SSE support intact; also decode `bytes` lines before parsing in stream loops.
- Adjust headers and upstream URL selection in `app/proxy.py`, update the health endpoint to report the selected upstream, and relax server startup in `app/server.py` so `GEMINI_API_KEY` is only required when `UPSTREAM_PROVIDER=gemini`.
- Files changed: `app/config.py`, `app/proxy.py`, `app/server.py`, `app/translator.py`, `tests/test_translator.py`.
- Assumptions: Ollama exposes a streaming newline-delimited JSON chat API at `OLLAMA_BASE_URL` and the text path is the primary compatibility requirement; advanced tool-calling parity with Gemini is out of scope for this change.
- Risks: Ollama support focuses on basic text/stream parity and does not normalize token/usage accounting, and tool/function-call flows may behave differently versus Gemini.

### Testing
- Ran `python -m unittest discover -s tests -q` and all tests passed (9 tests ran and succeeded).
- Ran `python -m unittest -q` which reported zero tests for that specific invocation but did not indicate failures.
- No other automated tests were modified; the new translator tests for Ollama payload/response conversions were added in `tests/test_translator.py` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d483f324832d8c2a8b296099af12)